### PR TITLE
Reset index opclasses after add_extension to prevent malformed schema.rb

### DIFF
--- a/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
+++ b/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb
@@ -306,6 +306,7 @@ module ActiveRecord
       def add_extension(extension_name, options={})
         raise UnsupportedFeature.new('Extensions are not support by this version of PostgreSQL') unless supports_extensions?
         execute "CREATE extension IF NOT EXISTS \"#{extension_name}\""
+        @opclasses = nil
       end
 
       def change_table(table_name, options = {})

--- a/spec/migrations/add_extension_spec.rb
+++ b/spec/migrations/add_extension_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe '#add_extension' do
+  let!(:connection) { ActiveRecord::Base.connection }
+  before(:each) do
+    connection.execute("DROP EXTENSION IF EXISTS #{extension}")
+  end
+
+  context 'pg_trgm' do
+    let(:extension) { 'pg_trgm' }
+
+    it 'adds the extension' do
+      expect{connection.add_extension(extension)}
+        .to change(&extension_exists?)
+        .from(false)
+        .to(true)
+    end
+
+    it 'clears the available index opclasses' do
+      expect{connection.add_extension(extension)}
+        .to change(&trigram_opclasses_available?)
+        .from(false)
+        .to(true)
+    end
+
+    def trigram_opclasses_available?
+      lambda do
+        trigram_opclasses = %w[gist_trgm_ops gin_trgm_ops]
+        (connection.opclasses & trigram_opclasses).any?
+      end
+    end
+  end
+
+  def extension_exists?
+    lambda do
+      connection.select_rows("select * from pg_extension where extname='#{extension}'").any?
+    end
+  end
+end


### PR DESCRIPTION
This fixes an issue in rails 3.2 where `add_extension` can cause the schema dumper to create a malformed `schema.rb`.

Some extensions like `pg_trgm` and `hstore` modify the available index opclasses in the `pg_opclass` table, but the query to this table is [memoized](https://github.com/dockyard/postgres_ext/blob/8288bfa1576eb7ec2e62af805955654ac2b19142/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb#L400-L402) for the entire lifetime of a connection, even though correctly determining the opclass when [dumping to schema.rb](https://github.com/dockyard/postgres_ext/blob/8288bfa1576eb7ec2e62af805955654ac2b19142/lib/postgres_ext/active_record/schema_dumper.rb#L123) [relies on the updated table](https://github.com/dockyard/postgres_ext/blob/8288bfa1576eb7ec2e62af805955654ac2b19142/lib/postgres_ext/active_record/connection_adapters/postgres_adapter.rb#L441).  The result is that a migration like

``` ruby
add_extension('pg_trgm')
add_index "items", "col", :name => "idx", :using => :gin, :index_opclass => :gin_trgm_ops
```

will generate a schema.rb that excludes the :index_opclass option:

``` ruby
add_index "items", ["col"], :name => "idx", :using => :gin
```

This is malformed since a gin index on a string column is illegal without an opclass, so running something that uses schema.rb such as rake db:test:prepare results in the following postgres error:

```
PG::UndefinedObject: ERROR:  data type character varying has no default operator class for access method "gin"
HINT:  You must specify an operator class for the index or define a default operator class for the data type.
```

Clearing the memoized variable after adding any extensions fixes this issue.
